### PR TITLE
Fix ApiResponses trait naming

### DIFF
--- a/backend/app/Http/Controllers/Api/AuthController.php
+++ b/backend/app/Http/Controllers/Api/AuthController.php
@@ -5,13 +5,13 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\LoginUserRequest;
 use App\Models\User;
-use App\Traits\ApiRespones;
+use App\Traits\ApiResponses;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class AuthController extends Controller
 {
-    use ApiRespones;
+    use ApiResponses;
 
     /**
      * Handle an authentication attempt.

--- a/backend/app/Traits/ApiResponses.php
+++ b/backend/app/Traits/ApiResponses.php
@@ -2,7 +2,7 @@
 
 namespace App\Traits;
 
-trait ApiRespones
+trait ApiResponses
 {
     protected function ok($message, $data, $statusCode = 200)
     {


### PR DESCRIPTION
## Summary
- rename ApiRespones to ApiResponses
- update imports and use statements for ApiResponses

## Testing
- `composer install --no-interaction --no-progress` *(fails: composer not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683ffd0ba4e88332a49eacbe23be37c3